### PR TITLE
Feature/pass username to skmutablepayment

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: .
   specs:
-    ProMotion-iap (0.1.0)
+    ProMotion-iap (0.2.0)
 
 GEM
   remote: https://rubygems.org/

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ class PurchaseScreen < PM::Screen
       }
     end
 
-    product.purchase do |status, transaction|
+    product.purchase do |status, data|
       case status
       when :in_progress
         # Usually do nothing, maybe a spinner
@@ -54,13 +54,16 @@ class PurchaseScreen < PM::Screen
         # They just canceled, no big deal.
       when :error
         # Failed to purchase
-        transaction.error.localizedDescription # => error message
+        data[:error].localizedDescription # => error message
       end
     end
 
-    product.restore do |status, product|
+    product.restore do |status, data|
       if status == :restored
         # Update your UI, notify the user
+        # data is a hash with :product_id, :error, and :transaction
+      else
+        # Tell the user it failed to restore
       end
     end
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ProMotion-iap
 
 [![Gem Version](https://badge.fury.io/rb/ProMotion-iap.svg)](http://badge.fury.io/rb/ProMotion-iap)
-[![Build Status](https://travis-ci.org/clearsightstudio/ProMotion-iap.svg)](https://travis-ci.org/clearsightstudio/ProMotion-iap) 
+[![Build Status](https://travis-ci.org/clearsightstudio/ProMotion-iap.svg)](https://travis-ci.org/clearsightstudio/ProMotion-iap)
 
 ProMotion-iap is in-app purchase notification support for the
  popular RubyMotion gem [ProMotion](https://github.com/clearsightstudio/ProMotion).
@@ -113,7 +113,7 @@ class PurchaseScreen < PM::Screen
       }, {...}]
     end
 
-    purchase_iap "productid" do |status, transaction|
+    purchase_iaps [ "productid" ], username: User.current.username do |status, transaction|
       case status
       when :in_progress
         # Usually do nothing, maybe a spinner
@@ -129,9 +129,13 @@ class PurchaseScreen < PM::Screen
       end
     end
 
-    restore_iaps "productid" do |status, products|
+    restore_iaps [ "productid" ], username: User.current.username do |status, transaction|
       if status == :restored
         # Update your UI, notify the user
+      elsif status == :error
+        # Update your UI to show that there was an error.
+        # `transaction` will be an error in this case.
+        transaction.localizedDescription # => description of error
       end
     end
 
@@ -155,7 +159,7 @@ Prompts the user to login to their Apple ID and complete the purchase. The callb
 #### restore_iaps(`*`product_ids, &callback)
 
 Restores a previously purchased IAP to the user (for example if they have upgraded their device). This relies on the Apple ID the user
- enters at the prompt. Unfortunately, if there is no purchase to restore for the signed-in account, no error message is generated and 
+ enters at the prompt. Unfortunately, if there is no purchase to restore for the signed-in account, no error message is generated and
  will fail silently.
 
 

--- a/README.md
+++ b/README.md
@@ -129,13 +129,16 @@ class PurchaseScreen < PM::Screen
       end
     end
 
-    restore_iaps [ "productid" ], username: User.current.username do |status, transaction|
+    restore_iaps [ "productid" ], username: User.current.username do |status, data|
       if status == :restored
         # Update your UI, notify the user
+        # This is called once for each product you're trying to restore.
+        data[:product_id] # => "productid"
       elsif status == :error
         # Update your UI to show that there was an error.
-        # `transaction` will be an error in this case.
-        transaction.localizedDescription # => description of error
+        # This will only be called once, no matter how many products you are trying to restore.
+        # You'll get an NSError in your `data` hash.
+        data[:error].localizedDescription # => description of error
       end
     end
 

--- a/lib/ProMotion/iap.rb
+++ b/lib/ProMotion/iap.rb
@@ -2,12 +2,15 @@ module ProMotion
   module IAP
     attr_accessor :completion_handlers
 
-    def purchase_iaps(*product_ids, &callback)
+    def purchase_iaps(product_ids, options={}, &callback)
       iap_setup
       retrieve_iaps product_ids do |products|
         products.each do |product|
           self.completion_handlers["purchase-#{product[:product_id]}"] = callback
-          payment = SKPayment.paymentWithProduct(product[:product])
+
+          payment = SKMutablePayment.paymentWithProduct(product[:product])
+          payment.applicationUsername = options[:username] if options[:username]
+
           SKPaymentQueue.defaultQueue.addPayment(payment)
         end
       end
@@ -19,8 +22,9 @@ module ProMotion
       retrieve_iaps product_ids do |products|
         products.each do |product|
           self.completion_handlers["restore-#{product[:product_id]}"] = callback
-          SKPaymentQueue.defaultQueue.restoreCompletedTransactions
         end
+
+        SKPaymentQueue.defaultQueue.restoreCompletedTransactions
       end
     end
     alias restore_iap restore_iaps

--- a/lib/ProMotion/iap.rb
+++ b/lib/ProMotion/iap.rb
@@ -29,7 +29,7 @@ module ProMotion
         end
 
         if options[:username]
-          puts "attempting to restore with username"
+          puts "attempting to restore with username: #{options[:username]}"
           SKPaymentQueue.defaultQueue.restoreCompletedTransactionsWithApplicationUsername(options[:username])
         else
           SKPaymentQueue.defaultQueue.restoreCompletedTransactions

--- a/lib/ProMotion/iap.rb
+++ b/lib/ProMotion/iap.rb
@@ -18,13 +18,18 @@ module ProMotion
     alias purchase_iap purchase_iaps
 
     def restore_iaps(product_ids, options={}, &callback)
+      puts "iap_setup"
       iap_setup
+      puts "attempting to retrieve_iaps #{product_ids}"
       retrieve_iaps Array(product_ids) do |products|
+        puts "in retrieve_iaps"
         products.each do |product|
+          puts "Adding completion_handler for #{product.inspect}"
           self.completion_handlers["restore-#{product[:product_id]}"] = callback
         end
 
         if options[:username]
+          puts "attempting to restore with username"
           SKPaymentQueue.defaultQueue.restoreCompletedTransactionsWithApplicationUsername(options[:username])
         else
           SKPaymentQueue.defaultQueue.restoreCompletedTransactions

--- a/lib/ProMotion/iap.rb
+++ b/lib/ProMotion/iap.rb
@@ -17,14 +17,18 @@ module ProMotion
     end
     alias purchase_iap purchase_iaps
 
-    def restore_iaps(*product_ids, &callback)
+    def restore_iaps(product_ids, options={}, &callback)
       iap_setup
-      retrieve_iaps product_ids do |products|
+      retrieve_iaps Array(product_ids) do |products|
         products.each do |product|
           self.completion_handlers["restore-#{product[:product_id]}"] = callback
         end
 
-        SKPaymentQueue.defaultQueue.restoreCompletedTransactions
+        if options[:username]
+          SKPaymentQueue.defaultQueue.restoreCompletedTransactionsWithApplicationUsername(options[:username])
+        else
+          SKPaymentQueue.defaultQueue.restoreCompletedTransactions
+        end
       end
     end
     alias restore_iap restore_iaps

--- a/spec/restore_iaps_spec.rb
+++ b/spec/restore_iaps_spec.rb
@@ -26,4 +26,19 @@ describe "#restore_iaps" do
     end
   end
 
+  context "error in restore" do
+    restored_transaction = mock_transaction.new(SKPaymentTransactionStateRestored, Struct.new(:code).new(nil), mock_payment.new("restoredproductid"))
+
+    it "returns success" do
+      subject = TestIAP.new
+      subject.mock!(:completion_handlers, return: {
+        "restore-all" => ->(status, transaction) {
+          status.should == :error
+          transaction.localizedDescription.should == "Failed to restore"
+        },
+      })
+      subject.paymentQueue(nil, restoreCompletedTransactionsFailedWithError:Struct.new(:localizedDescription).new("Failed to restore"))
+    end
+  end
+
 end

--- a/spec/restore_iaps_spec.rb
+++ b/spec/restore_iaps_spec.rb
@@ -21,7 +21,7 @@ describe "#restore_iaps" do
         "restore-restoredproductid" => ->(status, data) {
           status.should == :restored
           data[:product_id].should == "restoredproductid"
-          data[:error].should.be.nil
+          data[:error].code.should.be.nil
           data[:transaction].transactionState.should == SKPaymentTransactionStateRestored
         },
       })

--- a/spec/restore_iaps_spec.rb
+++ b/spec/restore_iaps_spec.rb
@@ -18,8 +18,11 @@ describe "#restore_iaps" do
     it "returns success" do
       subject = TestIAP.new
       subject.mock!(:completion_handlers, return: {
-        "restore-restoredproductid" => ->(status, transaction) {
+        "restore-restoredproductid" => ->(status, data) {
           status.should == :restored
+          data[:product_id].should == "restoredproductid"
+          data[:error].should.be.nil
+          data[:transaction].transactionState.should == SKPaymentTransactionStateRestored
         },
       })
       subject.paymentQueue(nil, updatedTransactions:[ restored_transaction ])
@@ -32,9 +35,11 @@ describe "#restore_iaps" do
     it "returns success" do
       subject = TestIAP.new
       subject.mock!(:completion_handlers, return: {
-        "restore-all" => ->(status, transaction) {
+        "restore-all" => ->(status, data) {
           status.should == :error
-          transaction.localizedDescription.should == "Failed to restore"
+          data[:product_id].should.be.nil
+          data[:error].localizedDescription.should == "Failed to restore"
+          data[:transaction].should.be.nil
         },
       })
       subject.paymentQueue(nil, restoreCompletedTransactionsFailedWithError:Struct.new(:localizedDescription).new("Failed to restore"))

--- a/spec/restore_iaps_spec.rb
+++ b/spec/restore_iaps_spec.rb
@@ -16,6 +16,7 @@ describe "#restore_iaps" do
     restored_transaction = mock_transaction.new(SKPaymentTransactionStateRestored, Struct.new(:code).new(nil), mock_payment.new("restoredproductid"))
 
     it "returns success" do
+      callback_called = false
       subject = TestIAP.new
       subject.mock!(:completion_handlers, return: {
         "restore-restoredproductid" => ->(status, data) {
@@ -23,9 +24,11 @@ describe "#restore_iaps" do
           data[:product_id].should == "restoredproductid"
           data[:error].code.should.be.nil
           data[:transaction].transactionState.should == SKPaymentTransactionStateRestored
+          callback_called = true
         },
       })
       subject.paymentQueue(nil, updatedTransactions:[ restored_transaction ])
+      callback_called.should.be.true
     end
   end
 
@@ -33,6 +36,7 @@ describe "#restore_iaps" do
     restored_transaction = mock_transaction.new(SKPaymentTransactionStateRestored, Struct.new(:code).new(nil), mock_payment.new("restoredproductid"))
 
     it "returns success" do
+      callback_called = false
       subject = TestIAP.new
       subject.mock!(:completion_handlers, return: {
         "restore-all" => ->(status, data) {
@@ -40,9 +44,11 @@ describe "#restore_iaps" do
           data[:product_id].should.be.nil
           data[:error].localizedDescription.should == "Failed to restore"
           data[:transaction].should.be.nil
+          callback_called = true
         },
       })
       subject.paymentQueue(nil, restoreCompletedTransactionsFailedWithError:Struct.new(:localizedDescription).new("Failed to restore"))
+      callback_called.should.be.true
     end
   end
 


### PR DESCRIPTION
A few updates:
- Can now pass a username to only allow that username to restore this purchase (this needs to be tested on-device better)
- There will now be a failure callback on unsuccessful restore (this also needs more testing on-device)
- Spec updates

@silasjmatson @kevinvangelder 
