### PR TITLE
Getting the product in case of Hash

### DIFF
--- a/lib/ProMotion/product.rb
+++ b/lib/ProMotion/product.rb
@@ -20,7 +20,8 @@ module ProMotion
 
     def restore(&callback)
       restore_iaps(product_id) do |status, products|
-        callback.call status, products.find{|p| p[:product_id] == product_id }
+        product = products.is_a?(Hash) ? products : products.find{|p| p[:product_id] == product_id }
+        callback.call status, product
       end
     end
   end


### PR DESCRIPTION
Not sure if this will fix issue #5, but surely does for me.
If clicking "Cancel" while restoring purchases, products variable in the block is not an array but an Hash, so the .find won't work.

Sorry for not very elegant solution, i was running for a quick win.
